### PR TITLE
Changed VALUE_OPTIONAL to VALUE_DEFAULT so that the phpunit test does…

### DIFF
--- a/classes/webservice/ws_providers.php
+++ b/classes/webservice/ws_providers.php
@@ -36,7 +36,7 @@ class ws_providers extends \external_api {
      */
     public static function service_parameters() {
         $parameters = [
-            'scope' => new \external_value(PARAM_ALPHA, 'Providers scope - all, enabled, disabled', VALUE_OPTIONAL, 'all')
+            'scope' => new \external_value(PARAM_ALPHA, 'Providers scope - all, enabled, disabled', VALUE_DEFAULT, 'all')
         ];
         return new \external_function_parameters($parameters);
     }


### PR DESCRIPTION
… not fail. The function call provides a default, so there should not be any unforeseen repercussions. After the patch, the phpunit tests completed successfully.