### PR TITLE
3.8 - Skip tests that rely on outside resources

### DIFF
--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -91,6 +91,9 @@ class filter_oembed_testcase extends advanced_testcase {
      */
     public function test_filter() {
         $this->resetAfterTest(true);
+        // This test is marked as skipped because, writing tests that rely
+        // on talking to the Internet are a very, very bad idea.
+        $this->markTestSkipped();
 
         $curl = new curl();
         try {

--- a/tests/oembed_test.php
+++ b/tests/oembed_test.php
@@ -92,6 +92,7 @@ class filter_oembed_service_testcase extends advanced_testcase {
      * TODO - have a local oembed service with test fixtures for performing test.
      */
     public function test_embed_html() {
+        $this->markTestSkipped("The youtube link is unavailabe");
         $this->resetAfterTest(true);
         set_config('lazyload', 0, 'filter_oembed');
         $this->setAdminUser();
@@ -107,6 +108,7 @@ class filter_oembed_service_testcase extends advanced_testcase {
      * TODO - have a local oembed service with test fixtures for performing test.
      */
     public function test_preloader_html() {
+        $this->markTestSkipped("The youtube link is unavailabe");
         $this->resetAfterTest(true);
         set_config('lazyload', 1, 'filter_oembed');
         $this->setAdminUser();


### PR DESCRIPTION
This PR marks some of the tests as skipped, because the tests were failing due to changes in the external resources.

Ideally these tests shouldn't rely on outside resources, but that is something that will have to be updated later.